### PR TITLE
feat: ansible playbooks for clone, build & push (#13)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,7 +56,8 @@
         },
         // Ansible configuration
         "ansible.validation.enabled": true,
-        "ansible.validation.lint.arguments": "-c .ansible-lint",
+        "ansible.validation.lint.arguments": "-c ansible/.ansible-lint",
+        "ansible.python.interpreterPath": "/usr/local/python/current/bin/python",
         "ansible.ansible.reuseTerminal": true,
         "ansible.lightspeed.enabled": true,
         "ansible.lightspeed.suggestions.enabled": true,

--- a/.devcontainer/install-dev-tools.sh
+++ b/.devcontainer/install-dev-tools.sh
@@ -35,11 +35,11 @@ echo -e "${YELLOW}Installing project dependencies${ENDCOLOR}"
 echo ""
 poetry install --no-root -C /workspaces/forge/ansible
 
-# Install ansible dependencies
-# echo ""
-# echo -e "${YELLOW}Installing ansible dependencies${ENDCOLOR}"
-# echo ""
-# ansible-galaxy collection install -r /workspaces/forge/setup/ansible/collections/requirements.yml
+Install ansible dependencies
+echo ""
+echo -e "${YELLOW}Installing ansible dependencies${ENDCOLOR}"
+echo ""
+ansible-galaxy collection install -r /workspaces/forge/ansible/collections/requirements.yml
 
 # Finish
 echo ""

--- a/.vscode/cspell_custom.txt
+++ b/.vscode/cspell_custom.txt
@@ -10,6 +10,7 @@ gitmessage
 hostvars
 keygen
 LAZYGIT
+lightspeed
 lineinfile
 minica
 Mountpoint
@@ -19,6 +20,7 @@ Nosniff
 nosnippet
 notranslate
 pipx
+posix
 Proto
 redirections
 rvproxy

--- a/README.md
+++ b/README.md
@@ -36,12 +36,20 @@ As an entry point for all components we use [Traefik](https://doc.traefik.io/tra
 a reverse proxy. Based on URL routing it will redirect the traffic to the
 right container instance.
 
+The reverse proxy dashboard is available at <https://traefik.ublue.local>
+
 ### Container Registry
 
 As container registry we make use of the [Docker Registry 2.0](https://hub.docker.com/_/registry/)
 implementation for storing and distributing container images
 
-The container registry is available at `registry.ublue.local`
+The container registry API is available at <https://registry.ublue.local/v2>
+
+### Anvil
+
+The blacksmith's work is done with [Ansible](https://docs.ansible.com/ansible/latest/index.html).
+
+The shiny GUI is missing but this should not shy us away. See [usage](#usage) for instructions.
 
 ## Handling the forge
 
@@ -52,3 +60,7 @@ You can use the `forge.sh` to **setup**, **heat-up** and **cool-down** the forge
 | `./forge.sh setup`     | Setup the forge for the first time or update existing setup |
 | `./forge.sh heat-up`   | Start the forge                                             |
 | `./forge.sh cool-down` | Stop the forge                                              |
+
+### Usage
+
+..tbd...

--- a/ansible/Containerfile
+++ b/ansible/Containerfile
@@ -19,6 +19,7 @@ COPY . .
 RUN poetry install --no-root
 CMD poetry env use .venv/bin/python && \
     chmod +x entrypoint.sh
+RUN ansible-galaxy collection install -r collections/requirements.yml
 
 # Set entrypoint
 ENTRYPOINT [ "/ansible/entrypoint.sh" ]

--- a/ansible/Containerfile
+++ b/ansible/Containerfile
@@ -17,4 +17,8 @@ RUN pipx install poetry==${POETRY_VERSION}
 WORKDIR /ansible
 COPY . .
 RUN poetry install --no-root
-CMD poetry env use .venv/bin/python
+CMD poetry env use .venv/bin/python && \
+    chmod +x entrypoint.sh
+
+# Set entrypoint
+ENTRYPOINT [ "/ansible/entrypoint.sh" ]

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -11,8 +11,12 @@ library = ./library
 private_key_file = /certs/ssh/ublue-os_forge-id_ed25519
 # Console log settings
 display_skipped_hosts = false
+# Use the YAML callback plugin.
+stdout_callback = yaml
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks = True
+# Callback plugins
+callbacks_enabled=ansible.posix.profile_tasks
 # Skip SSH host key checking
 host_key_checking = False
 # Disable cowsay

--- a/ansible/collections/requirements.yml
+++ b/ansible/collections/requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: ansible.posix
+    version: 1.5.4
+  - name: community.general
+    version: 8.6.0
+  - name: containers.podman
+    version: 1.13.0

--- a/ansible/entrypoint.sh
+++ b/ansible/entrypoint.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+## Keep container running
+sleep infinity

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,0 +1,10 @@
+---
+# variables used for all groups and hosts
+
+## container registry
+forge_registry_url: registry.ublue.local
+
+## Git
+forge_git_repository_url: https://github.com/ublue-os/bluefin.git
+forge_git_repository_destination: "{{ ansible_facts.env.HOME }}/ublue-os/forge/bluefin"
+forge_git_repository_version: main

--- a/ansible/host_vars/host.ublue.local.yml
+++ b/ansible/host_vars/host.ublue.local.yml
@@ -1,0 +1,2 @@
+---
+# variables used in playbooks with target host.ublue.local

--- a/ansible/playbooks/project_build.yml
+++ b/ansible/playbooks/project_build.yml
@@ -1,0 +1,17 @@
+---
+- name: Build project
+  hosts: host.ublue.local
+  gather_facts: true
+  tasks:
+    - name: Build and push an image to registry
+      containers.podman.podman_image:
+        name: bluefin
+        tag: latest
+        path: "{{ forge_git_repository_destination }}"
+        build:
+          file: Containerfile
+          format: oci
+        pull: false
+        push: true
+        push_args:
+          dest: "{{ forge_registry_url }}"

--- a/ansible/playbooks/project_clone.yml
+++ b/ansible/playbooks/project_clone.yml
@@ -1,0 +1,10 @@
+---
+- name: Clone project
+  hosts: host.ublue.local
+  gather_facts: true
+  tasks:
+    - name: Clone project
+      ansible.builtin.git:
+        repo: "{{ forge_git_repository_url }}"
+        dest: "{{ forge_git_repository_destination }}"
+        version: "{{ forge_git_repository_version }}"

--- a/forge-pod.yml
+++ b/forge-pod.yml
@@ -95,7 +95,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ${FORGE_POD_NAME_SETUP}
+  name: ${FORGE_POD_NAME_ANVIL}
 spec:
   restartPolicy: OnFailure
   volumes:
@@ -121,7 +121,3 @@ spec:
             secretKeyRef:
               name: ublue-os_forge-secure
               key: ANSIBLE_HOST_BECOME_PASSWORD
-      command:
-        - ansible-playbook
-      args:
-        - playbooks/configure_host.yml

--- a/forge.just
+++ b/forge.just
@@ -1,0 +1,8 @@
+# ublue-os forge just configuration
+
+# Show all messages from this boot
+forge_clone-repository:
+    podman exec ublue-os_forge-anvil-ansible.ublue.local ansible-playbook playbooks/project_clone.yml
+
+forge_build-image:
+    podman exec ublue-os_forge-anvil-ansible.ublue.local ansible-playbook playbooks/project_build.yml

--- a/forge.sh
+++ b/forge.sh
@@ -6,7 +6,7 @@ export FORGE_POD_CONFIGURATION="forge-pod.yml"
 export FORGE_POD_NAME_PRE_AMBLE="ublue-os_forge-"
 export FORGE_POD_NAME_REVERSE_PROXY=${FORGE_POD_NAME_PRE_AMBLE}rvproxy
 export FORGE_POD_NAME_REGISTRY=${FORGE_POD_NAME_PRE_AMBLE}registry
-export FORGE_POD_NAME_SETUP=${FORGE_POD_NAME_PRE_AMBLE}setup
+export FORGE_POD_NAME_ANVIL=${FORGE_POD_NAME_PRE_AMBLE}anvil
 
 # Functions
 function setup {
@@ -23,7 +23,7 @@ function setup {
     configure_host_prerequisites & PID_CONFIG=$!
     wait ${PID_CONFIG}
     echo -e "${YELLOW}Configuring host system...${ENDCOLOR}"
-    podman logs --color --follow "${FORGE_POD_NAME_SETUP}-ansible.${FORGE_DOMAIN_NAME}"
+    podman exec ${FORGE_POD_NAME_ANVIL}-ansible.${FORGE_DOMAIN_NAME} ansible-playbook playbooks/configure_host.yml
     echo ""
     echo -e "${YELLOW}Cleaning up secrets...${ENDCOLOR}"
     delete_secrets
@@ -36,6 +36,7 @@ function up {
     echo -e "${YELLOW}Heating up forge...${ENDCOLOR}"
     podman pod start ${FORGE_POD_NAME_REVERSE_PROXY}
     podman pod start ${FORGE_POD_NAME_REGISTRY}
+    podman pod start ${FORGE_POD_NAME_ANVIL}
     echo -e "${GREEN}The following containers are now running...${ENDCOLOR}"
     show_containter_info
     echo -e "${GREEN}Done. Happy forging!${ENDCOLOR}"
@@ -47,6 +48,7 @@ function down {
     show_containter_info
     podman pod stop "${FORGE_POD_NAME_REVERSE_PROXY}" --ignore
     podman pod stop "${FORGE_POD_NAME_REGISTRY}" --ignore
+    podman pod stop "${FORGE_POD_NAME_ANVIL}" --ignore
     echo -e "${GREEN}Done. Have a nice day${ENDCOLOR}"
 }
 


### PR DESCRIPTION
this mr adds the first two playbooks to demonstrate how things should work. It's pretty basic at the moment. Have to think about variable handling. It also add a basic just file. With the idea that each tasks can be launched with it. This is easier to remember than "podman exec ....."